### PR TITLE
Corrected error in sort_custom section of class_array.rst

### DIFF
--- a/classes/class_array.rst
+++ b/classes/class_array.rst
@@ -1304,7 +1304,7 @@ Sorts the array using a custom :ref:`Callable<class_Callable>`.
         print(my_items) # Prints [["Rice", 4], ["Tomato", 5], ["Apple", 9]]
     
         # Sort descending, using a lambda function.
-        my_items.sort_custom(func(a, b): return a[0] > b[0])
+        my_items.sort_custom(func(a, b): return a[1] > b[1])
         print(my_items) # Prints [["Apple", 9], ["Tomato", 5], ["Rice", 4]]
 
 It may also be necessary to use this method to sort strings by natural order, with :ref:`String.naturalnocasecmp_to<class_String_method_naturalnocasecmp_to>`, as in the following example:


### PR DESCRIPTION
Corrected the array indices used in the lambda function of the sort descending example to match the indices used in the function  sort_ascending.  

As written:
```
func sort_ascending(a, b):
	if a[1] < b[1]:
		return true
	return false
```

in ready function:

```
	my_items.sort_custom(func(a, b): return a[0] > b[0])
	print(my_items) # Prints [["Apple", 9], ["Tomato", 5], ["Rice", 4]]
```

As written, the output is incorrect, as it would print in Tomato, Rice, Apple order

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
